### PR TITLE
migrate yolov8 code to tensorrt 10.x API

### DIFF
--- a/include/yolov8.hpp
+++ b/include/yolov8.hpp
@@ -1,9 +1,11 @@
 //
 // Created by  triple-Mu     on 24-1-2023.
-// Modified by Q-engineering on  6-3-2024
+// Modified by Q-engineering on  6-3-2024,
+// Modified by niklasrah     on 9-12-2025,
 //
 #ifndef DETECT_NORMAL_YOLOV8_HPP
 #define DETECT_NORMAL_YOLOV8_HPP
+
 #include "NvInferPlugin.h"
 #include "common.hpp"
 #include "fstream"
@@ -11,33 +13,47 @@
 using namespace det;
 
 class YOLOv8 {
-private:
-    nvinfer1::ICudaEngine*       engine  = nullptr;
-    nvinfer1::IRuntime*          runtime = nullptr;
-    nvinfer1::IExecutionContext* context = nullptr;
-    cudaStream_t                 stream  = nullptr;
-    Logger                       gLogger{nvinfer1::ILogger::Severity::kERROR};
-public:
-    int                  num_bindings;
-    int                  num_inputs  = 0;
-    int                  num_outputs = 0;
-    std::vector<Binding> input_bindings;
-    std::vector<Binding> output_bindings;
-    std::vector<void*>   host_ptrs;
-    std::vector<void*>   device_ptrs;
+    public:
+        explicit YOLOv8(const std::string& engine_file_path);
+        ~YOLOv8();
 
-    PreParam pparam;
+        void MakePipe(bool warmup = true);
+        void CopyFromMat(const cv::Mat& image);
+        void CopyFromMat(const cv::Mat& image, cv::Size& size);
+        void Letterbox(const cv::Mat& image, cv::Mat& out, cv::Size& size);
+        void Infer();
+        void PostProcess(std::vector<Object>& objs, float score_thres, float iou_thres, int topk, int num_labels  = 80);
+        void DrawObjects(cv::Mat& bgr, const std::vector<Object>& objs);
 
-public:
-    explicit YOLOv8(const std::string& engine_file_path);
-    ~YOLOv8();
+    private:
+        // TensorRT objects
+        nvinfer1::ICudaEngine* engine  = nullptr;
+        nvinfer1::IRuntime* runtime = nullptr;
+        nvinfer1::IExecutionContext* context = nullptr;
 
-    void                 MakePipe(bool warmup = true);
-    void                 CopyFromMat(const cv::Mat& image);
-    void                 CopyFromMat(const cv::Mat& image, cv::Size& size);
-    void                 Letterbox(const cv::Mat& image, cv::Mat& out, cv::Size& size);
-    void                 Infer();
-    void                 PostProcess(std::vector<Object>& objs, float score_thres, float iou_thres, int topk, int num_labels  = 80);
-    void                 DrawObjects(cv::Mat& bgr, const std::vector<Object>& objs);
+        // TensorRT objects
+        cudaStream_t stream  = nullptr;
+
+        // Bindings (now name-based)
+        std::vector<Binding> input_bindings;
+        std::vector<Binding> output_bindings;
+
+        // Buffers
+        std::vector<void*> device_ptrs;  // inputs first, then outputs
+        std::vector<void*> host_ptrs;    // host pinned outputs only
+
+        // logger
+        Logger gLogger{nvinfer1::ILogger::Severity::kERROR};
+
+        // changed to num_iotensors for name-based bindings
+        int num_iotensors = 0;
+        int num_inputs = 0;
+        int num_outputs = 0;
+
+        PreParam pparam;
+
+        // helpers
+        size_t get_size_by_dims_local(const nvinfer1::Dims& d) { return static_cast<size_t>(get_size_by_dims(d)); }
+
 };
 #endif  // DETECT_NORMAL_YOLOV8_HPP

--- a/src/yolov8.cpp
+++ b/src/yolov8.cpp
@@ -1,6 +1,7 @@
 //
 // Created by  triple-Mu     on 24-1-2023.
-// Modified by Q-engineering on  6-3-2024
+// Modified by Q-engineering on  6-3-2024,
+// Modified by niklasrah     on 9-12-2025,
 //
 
 #include "yolov8.hpp"
@@ -24,61 +25,63 @@ const char* class_names[] = {
 //----------------------------------------------------------------------------------------
 YOLOv8::YOLOv8(const std::string& engine_file_path)
 {
+    // Read engine file
     std::ifstream file(engine_file_path, std::ios::binary);
     assert(file.good());
     file.seekg(0, std::ios::end);
-    auto size = file.tellg();
+    std::streamsize size = file.tellg();
     file.seekg(0, std::ios::beg);
-    char* trtModelStream = new char[size];
-    assert(trtModelStream);
-    file.read(trtModelStream, size);
+    std::vector<char> trtModelStream(static_cast<size_t>(size));
+    file.read(trtModelStream.data(), size);
     file.close();
+
+    // init plugins & runtime
     initLibNvInferPlugins(&this->gLogger, "");
     this->runtime = nvinfer1::createInferRuntime(this->gLogger);
     assert(this->runtime != nullptr);
 
-    this->engine = this->runtime->deserializeCudaEngine(trtModelStream, size);
+    // TRT10: deserializeCudaEngine has a third parameter (IHostMemoryProvider* or nullptr)
+    this->engine = this->runtime->deserializeCudaEngine(trtModelStream.data(), static_cast<size_t>(size));
     assert(this->engine != nullptr);
-    delete[] trtModelStream;
+
+    // create context
     this->context = this->engine->createExecutionContext();
-
     assert(this->context != nullptr);
-    cudaStreamCreate(&this->stream);
-    this->num_bindings = this->engine->getNbBindings();
 
-    for (int i = 0; i < this->num_bindings; ++i) {
-        Binding            binding;
-        nvinfer1::Dims     dims;
-        nvinfer1::DataType dtype = this->engine->getBindingDataType(i);
-        std::string        name  = this->engine->getBindingName(i);
-        binding.name             = name;
-        binding.dsize            = type_to_size(dtype);
+    // create stream
+    CHECK(cudaStreamCreate(&this->stream));
 
-        bool IsInput = engine->bindingIsInput(i);
-        if (IsInput) {
-            this->num_inputs += 1;
-            dims         = this->engine->getProfileDimensions(i, 0, nvinfer1::OptProfileSelector::kMAX);
-            binding.size = get_size_by_dims(dims);
-            binding.dims = dims;
-            this->input_bindings.push_back(binding);
-            // set max opt shape
-            this->context->setBindingDimensions(i, dims);
-        }
-        else {
-            dims         = this->context->getBindingDimensions(i);
-            binding.size = get_size_by_dims(dims);
-            binding.dims = dims;
-            this->output_bindings.push_back(binding);
-            this->num_outputs += 1;
+    // discover I/O tensors (name-based)
+    this->num_iotensors = this->engine->getNbIOTensors();
+    for (int i = 0; i < this->num_iotensors; ++i) {
+        const char* tname = this->engine->getIOTensorName(i);
+        assert(tname != nullptr);
+        nvinfer1::TensorIOMode mode = this->engine->getTensorIOMode(tname);
+        nvinfer1::DataType dtype = this->engine->getTensorDataType(tname);
+        nvinfer1::Dims dims = this->engine->getTensorShape(tname);  // static shape in engine or profile shape
+
+        det::Binding b;
+        b.name = std::string(tname);
+        b.dsize = static_cast<size_t>(type_to_size(dtype));
+        b.dims = dims;
+        b.size = get_size_by_dims_local(dims);
+
+        if (mode == nvinfer1::TensorIOMode::kINPUT) {
+            input_bindings.push_back(b);
+            ++this->num_inputs;
+        } else {
+            output_bindings.push_back(b);
+            ++this->num_outputs;
         }
     }
+
 }
 //----------------------------------------------------------------------------------------
 YOLOv8::~YOLOv8()
 {
-    this->context->destroy();
-    this->engine->destroy();
-    this->runtime->destroy();
+    delete this->context;
+    delete this->engine;
+    delete this->runtime;
     cudaStreamDestroy(this->stream);
     for (auto& ptr : this->device_ptrs) {
         CHECK(cudaFree(ptr));
@@ -95,37 +98,56 @@ void YOLOv8::MakePipe(bool warmup)
 #error CUDART_VERSION Undefined!
 #endif
 
-    for (auto& bindings : this->input_bindings) {
-        void* d_ptr;
-#if(CUDART_VERSION < 11000)
-        CHECK(cudaMalloc(&d_ptr, bindings.size * bindings.dsize));
+    for (auto& inb : this->input_bindings) {
+        void* d_ptr = nullptr;
+        size_t bytes = inb.size * inb.dsize;
+#if (CUDART_VERSION < 11000)
+        CHECK(cudaMalloc(&d_ptr, bytes));
 #else
-        CHECK(cudaMallocAsync(&d_ptr, bindings.size * bindings.dsize, this->stream));
+        CHECK(cudaMallocAsync(&d_ptr, bytes, this->stream));
 #endif
         this->device_ptrs.push_back(d_ptr);
     }
 
-    for (auto& bindings : this->output_bindings) {
-        void * d_ptr, *h_ptr;
-        size_t size = bindings.size * bindings.dsize;
-#if(CUDART_VERSION < 11000)
-        CHECK(cudaMalloc(&d_ptr, bindings.size * bindings.dsize));
+    for (auto& outb : this->output_bindings) {
+        void* d_ptr = nullptr;
+        void* h_ptr = nullptr;
+        size_t bytes = outb.size * outb.dsize;
+#if (CUDART_VERSION < 11000)
+        CHECK(cudaMalloc(&d_ptr, bytes));
 #else
-        CHECK(cudaMallocAsync(&d_ptr, bindings.size * bindings.dsize, this->stream));
+        CHECK(cudaMallocAsync(&d_ptr, bytes, this->stream));
 #endif
-        CHECK(cudaHostAlloc(&h_ptr, size, 0));
+        CHECK(cudaHostAlloc(&h_ptr, bytes, 0));
         this->device_ptrs.push_back(d_ptr);
         this->host_ptrs.push_back(h_ptr);
     }
 
+    // Map buffers to tensor names (required for TRT10)
+    int devIndex = 0;
+
+    // Assign input tensor addresses
+    for (size_t i = 0; i < input_bindings.size(); ++i) {
+        const char* name = input_bindings[i].name.c_str();
+        void* d_ptr = device_ptrs[devIndex++];
+        context->setTensorAddress(name, d_ptr);
+    }
+
+    // Assign output tensor addresses
+    for (size_t i = 0; i < output_bindings.size(); ++i) {
+        const char* name = output_bindings[i].name.c_str();
+        void* d_ptr = device_ptrs[devIndex++];
+        context->setTensorAddress(name, d_ptr);
+    }
+
+    // optional warmup
     if (warmup) {
-        for (int i = 0; i < 10; i++) {
-            for (auto& bindings : this->input_bindings) {
-                size_t size  = bindings.size * bindings.dsize;
-                void*  h_ptr = malloc(size);
-                memset(h_ptr, 0, size);
-                CHECK(cudaMemcpyAsync(this->device_ptrs[0], h_ptr, size, cudaMemcpyHostToDevice, this->stream));
-                free(h_ptr);
+        for (int k = 0; k < 5; ++k) {
+            // zero input buffers and copy
+            for (size_t i = 0; i < this->input_bindings.size(); ++i) {
+                size_t bytes = this->input_bindings[i].size * this->input_bindings[i].dsize;
+                std::vector<char> zeros(bytes, 0);
+                CHECK(cudaMemcpyAsync(this->device_ptrs[i], zeros.data(), bytes, cudaMemcpyHostToDevice, this->stream));
             }
             this->Infer();
         }
@@ -136,8 +158,8 @@ void YOLOv8::Letterbox(const cv::Mat& image, cv::Mat& out, cv::Size& size)
 {
     const float inp_h  = size.height;
     const float inp_w  = size.width;
-    float       height = image.rows;
-    float       width  = image.cols;
+    float       height = static_cast<float>(image.rows);
+    float       width  = static_cast<float>(image.cols);
 
     float r    = std::min(inp_h / height, inp_w / width);
     int   padw = std::round(width * r);
@@ -169,50 +191,62 @@ void YOLOv8::Letterbox(const cv::Mat& image, cv::Mat& out, cv::Size& size)
     this->pparam.dh     = dh;
     this->pparam.height = height;
     this->pparam.width  = width;
-    ;
 }
 //----------------------------------------------------------------------------------------
 void YOLOv8::CopyFromMat(const cv::Mat& image)
 {
-    cv::Mat  nchw;
-    auto&    in_binding = this->input_bindings[0];
-    auto     width      = in_binding.dims.d[3];
-    auto     height     = in_binding.dims.d[2];
+    cv::Mat nchw;
+    // assume single input
+    assert(this->input_bindings.size() > 0);
+    auto& in_binding = this->input_bindings[0];
+    // Get target width/height from input binding dims (expect dims format: {N,C,H,W} or nbDims==4)
+    int width = (in_binding.dims.nbDims >= 4) ? in_binding.dims.d[3] : 640;
+    int height = (in_binding.dims.nbDims >= 4) ? in_binding.dims.d[2] : 640;
     cv::Size size{width, height};
     this->Letterbox(image, nchw, size);
 
-    this->context->setBindingDimensions(0, nvinfer1::Dims{4, {1, 3, height, width}});
+    // set input shape by name (TensorRT 10 name-based API)
+    nvinfer1::Dims4 shape{1, 3, height, width};
+    this->context->setInputShape(in_binding.name.c_str(), shape);
 
-    CHECK(cudaMemcpyAsync(
-        this->device_ptrs[0], nchw.ptr<float>(), nchw.total() * nchw.elemSize(), cudaMemcpyHostToDevice, this->stream));
+    size_t bytes = nchw.total() * nchw.elemSize();
+    CHECK(cudaMemcpyAsync(this->device_ptrs[0], nchw.ptr<float>(), bytes, cudaMemcpyHostToDevice, this->stream));
 }
 //----------------------------------------------------------------------------------------
 void YOLOv8::CopyFromMat(const cv::Mat& image, cv::Size& size)
 {
     cv::Mat nchw;
     this->Letterbox(image, nchw, size);
-    this->context->setBindingDimensions(0, nvinfer1::Dims{4, {1, 3, size.height, size.width}});
-    CHECK(cudaMemcpyAsync(
-        this->device_ptrs[0], nchw.ptr<float>(), nchw.total() * nchw.elemSize(), cudaMemcpyHostToDevice, this->stream));
+
+    assert(this->input_bindings.size() > 0);
+    auto& in_binding = this->input_bindings[0];
+    nvinfer1::Dims4 shape{1, 3, size.height, size.width};
+    this->context->setInputShape(in_binding.name.c_str(), shape);
+
+    size_t bytes = nchw.total() * nchw.elemSize();
+    CHECK(cudaMemcpyAsync(this->device_ptrs[0], nchw.ptr<float>(), bytes, cudaMemcpyHostToDevice, this->stream));
 }
 //----------------------------------------------------------------------------------------
 void YOLOv8::Infer()
 {
-
-    this->context->enqueueV2(this->device_ptrs.data(), this->stream, nullptr);
-    for (int i = 0; i < this->num_outputs; i++) {
+    // On TRT10 use enqueueV3 (name-based tensors still require raw device pointer array)
+    this->context->enqueueV3(this->stream);
+    // copy outputs back to host; outputs start at index num_inputs
+    for (int i = 0; i < this->num_outputs; ++i) {
         size_t osize = this->output_bindings[i].size * this->output_bindings[i].dsize;
-        CHECK(cudaMemcpyAsync(
-            this->host_ptrs[i], this->device_ptrs[i + this->num_inputs], osize, cudaMemcpyDeviceToHost, this->stream));
+        void* devPtr = this->device_ptrs[i + this->num_inputs];
+        void* hostPtr = this->host_ptrs[i];
+        CHECK(cudaMemcpyAsync(hostPtr, devPtr, osize, cudaMemcpyDeviceToHost, this->stream));
     }
-    cudaStreamSynchronize(this->stream);
+    CHECK(cudaStreamSynchronize(this->stream));
 }
 //----------------------------------------------------------------------------------------
 void YOLOv8::PostProcess(std::vector<Object>& objs, float score_thres, float iou_thres, int topk, int num_labels)
 {
     objs.clear();
-    auto num_channels = this->output_bindings[0].dims.d[1];
-    auto num_anchors  = this->output_bindings[0].dims.d[2];
+    assert(this->output_bindings.size() > 0);
+    auto num_channels = this->output_bindings[0].dims.nbDims > 1 ? this->output_bindings[0].dims.d[1] : 85;  // fallback
+    auto num_anchors = this->output_bindings[0].dims.nbDims > 2 ? this->output_bindings[0].dims.d[2] : (this->output_bindings[0].size / num_channels);
 
     auto& dw     = this->pparam.dw;
     auto& dh     = this->pparam.dh;
@@ -244,7 +278,7 @@ void YOLOv8::PostProcess(std::vector<Object>& objs, float score_thres, float iou
             float x1 = clamp((x + 0.5f * w) * ratio, 0.f, width);
             float y1 = clamp((y + 0.5f * h) * ratio, 0.f, height);
 
-            int              label = max_s_ptr - scores_ptr;
+            int label = max_s_ptr - scores_ptr;
             cv::Rect_<float> bbox;
             bbox.x      = x0;
             bbox.y      = y0;
@@ -291,13 +325,11 @@ void YOLOv8::DrawObjects(cv::Mat& bgr, const std::vector<Object>& objs)
 
         int x = (int)obj.rect.x;
         int y = (int)obj.rect.y - label_size.height - baseLine;
-
         if (y < 0)        y = 0;
         if (y > bgr.rows) y = bgr.rows;
         if (x + label_size.width > bgr.cols) x = bgr.cols - label_size.width;
 
         cv::rectangle(bgr, cv::Rect(cv::Point(x, y), cv::Size(label_size.width, label_size.height + baseLine)), cv::Scalar(255, 255, 255), -1);
-
         cv::putText(bgr, text, cv::Point(x, y + label_size.height), cv::FONT_HERSHEY_SIMPLEX, 0.5, cv::Scalar(0, 0, 0));
     }
 }


### PR DESCRIPTION
Hi,

i migrate the Yolov8.cpp and Yolov8.hpp code to the new TensorRT API 10.x. I tested this on a NVIDIA Jetson Orin NX, and it worked. Maybe you can add a seperate branch to switch to the new trt version.